### PR TITLE
Fix finding measurement type in file import services

### DIFF
--- a/Backend-java/src/main/java/engineeringthesis/model/jpa/enums/PollutionMeasurementType.java
+++ b/Backend-java/src/main/java/engineeringthesis/model/jpa/enums/PollutionMeasurementType.java
@@ -5,7 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -24,4 +26,12 @@ public enum PollutionMeasurementType {
         }
         return names;
     }
+
+    public static PollutionMeasurementType findByValue(String value) {
+        List<PollutionMeasurementType> res = Arrays.stream(PollutionMeasurementType.values())
+                .filter(pmt -> pmt.getValue().equalsIgnoreCase(value))
+                .collect(Collectors.toList());
+        return res.size() > 0 ? res.get(0) : null;
+    }
+
 }

--- a/Backend-java/src/main/java/engineeringthesis/model/jpa/enums/WeatherMeasurementType.java
+++ b/Backend-java/src/main/java/engineeringthesis/model/jpa/enums/WeatherMeasurementType.java
@@ -4,7 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -25,4 +27,12 @@ public enum WeatherMeasurementType {
         }
         return names;
     }
+
+    public static WeatherMeasurementType findByValue(String value) {
+        List<WeatherMeasurementType> res = Arrays.stream(WeatherMeasurementType.values())
+                .filter(wmt -> wmt.getValue().equalsIgnoreCase(value))
+                .collect(Collectors.toList());
+        return res.size() > 0 ? res.get(0) : null;
+    }
+
 }

--- a/Backend-java/src/main/java/engineeringthesis/service/CsvImportService.java
+++ b/Backend-java/src/main/java/engineeringthesis/service/CsvImportService.java
@@ -78,10 +78,11 @@ public class CsvImportService {
                 (name, columnNo) -> {
                     String value = line[columnNo];
                     if (!value.equalsIgnoreCase("")) {
+
                         pollutionService.addPollution(
                                 Pollution.builder()
                                         .measurement(measurement)
-                                        .measurementType(PollutionMeasurementType.valueOf(name))
+                                        .measurementType(PollutionMeasurementType.findByValue(name))
                                         .measurementValue(Double.valueOf(line[columnNo]))
                                         .build());
                     }

--- a/Backend-java/src/main/java/engineeringthesis/service/XlsImportService.java
+++ b/Backend-java/src/main/java/engineeringthesis/service/XlsImportService.java
@@ -86,7 +86,7 @@ public class XlsImportService {
                         pollutionService.addPollution(
                                 Pollution.builder()
                                         .measurement(measurement)
-                                        .measurementType(PollutionMeasurementType.valueOf(name))
+                                        .measurementType(PollutionMeasurementType.findByValue(name))
                                         .measurementValue(c.getNumericCellValue())
                                         .build());
                     }


### PR DESCRIPTION
Spolszczenie zepsuło znajdowanie typu pomiaru.
Dotychczas np. w przypadku kolumny z PM10, zmienna name zawierała "PM10"
Teraz zawiera "Pył PM10", więc valueOf tego nie znajdzie